### PR TITLE
changing the domain name for fairshare sources.

### DIFF
--- a/docs/service/createMarkdown.groovy
+++ b/docs/service/createMarkdown.groovy
@@ -77,7 +77,7 @@ if (dataFile != "template.json") {
     if (line.contains("%instance.docker%")) { line = processRich(line, data, "instance.docker", "[%instance.docker%](%instance.docker%)") }
     if (line.contains("%ELIXIR.biotools%")) { line = processRich(line, data, "ELIXIR.biotools", "[https://bio.tools/%ELIXIR.biotools%](https://bio.tools/%ELIXIR.biotools%)") }
     if (line.contains("%ELIXIR.tess%")) { line = processRich(line, data, "ELIXIR.tess", "[https://tess.elixir-europe.org/search?q=%ELIXIR.tess%](https://tess.elixir-europe.org/search?q=%ELIXIR.tess%)") }
-    if (line.contains("%ELIXIR.fairsharing%")) { line = processRich(line, data, "ELIXIR.fairsharing", "[https://doi.org/?q=%ELIXIR.fairsharing%](https://doi.org/?q=%ELIXIR.fairsharing%)") }
+    if (line.contains("%ELIXIR.fairsharing%")) { line = processRich(line, data, "ELIXIR.fairsharing", "[https://fairsharing.org/%ELIXIR.fairsharing%](https://fairsharing.org/%ELIXIR.fairsharing%)") }
     if (line.contains("%ELIXIR.tess.noExpand%")) { line = process(line, data, "ELIXIR.tess.noExpand") }
     if (line.contains("%Other.wikipedia%")) { line = processRich(line, data, "Other.wikipedia", "[%instance.docker%](https://en.wikipedia.org/wiki/%Other.wikipedia%)") }
     if (line.contains("%Other.rsd%")) { line = processRich(line, data, "Other.rsd", "[%Other.rsd%](https://research-software-directory.org/software/%Other.rsd%)") }


### PR DESCRIPTION
The reason for this suggestion is that when the [fairsharing item](https://github.com/VHP4Safety/cloud/blob/2bff480940199f5fee94f60df3baaf79cf070152/docs/service/template.json#L147) in the template.json is filled, the link in the .md file is not created correctly by `createMarkdown.groovy`.

Here's an example. The [fairsharing item for BridgeDB](https://github.com/VHP4Safety/cloud/blob/2bff480940199f5fee94f60df3baaf79cf070152/docs/service/bridgedb.json#L29) is filled with an identifier. Then, `createMarkdown.groovy` creates the link in [the .md file](https://github.com/VHP4Safety/cloud/blob/main/docs/service/bridgedb.md) as `https://doi.org/?q=10.25504/FAIRsharing.5ry74y`. However, if you try to go to that [link](https://doi.org/?q=10.25504/FAIRsharing.5ry74y), you don't find the material. I think the correct [link](https://fairsharing.org/10.25504/FAIRsharing.5ry74y) is `https://fairsharing.org/10.25504/FAIRsharing.5ry74y`. So, `createMarkdown.groovy` may need to use `fairsharing.org` as the domain name rather than `doi.org` for this item. 