### PR TITLE
Add developed-by-VHP and vhp-partner fields to service catalog

### DIFF
--- a/docs/service/aop-builder.json
+++ b/docs/service/aop-builder.json
@@ -5,6 +5,7 @@
   "stage":"https://vhp4safety.github.io/glossary#VHP0000156",
   "substage":"https://vhp4safety.github.io/glossary#VHP0000023",
   "url": "https://crebuilder.vhp4safety.nl",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "url": "https://crebuilder.vhp4safety.nl",
@@ -14,7 +15,8 @@
   "provider": {
     "contact": {
       "name": "Marc Teunis",
-      "email": "marc.teunis@hu.nl"
+      "email": "marc.teunis@hu.nl",
+      "vhp-partner": "Hogeschool Utrecht"
     }
   },
   "regulatory-question": {

--- a/docs/service/aopsuite.json
+++ b/docs/service/aopsuite.json
@@ -6,6 +6,7 @@
   "substage": "https://vhp4safety.github.io/glossary#VHP0000023",
   "screenshot": "aopsuite.png",
   "url": "",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -19,7 +20,8 @@
   "provider": {
     "contact": {
       "name": "Javier Millán Acosta",
-      "email": "javier.millanacosta@maastrichtuniversity.nl"
+      "email": "javier.millanacosta@maastrichtuniversity.nl",
+      "vhp-partner": "Maastricht University"
     },
     "url": "https://www.maastrichtuniversity.nl/research/translational-genomics",
     "name": "Department of Translational Genomics, Maastricht University"

--- a/docs/service/aopwiki.json
+++ b/docs/service/aopwiki.json
@@ -7,6 +7,7 @@
   "screenshot": "aopwiki.png",
   "url": "https://aopwiki.rdf.bigcat-bioinformatics.org/",
   "doi": "10.1089/aivt.2021.0010",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -25,7 +26,8 @@
   "provider": {
     "contact": {
       "name": "Marvin Martens",
-      "email": "marvin.martens@maastrichtuniversity.nl"
+      "email": "marvin.martens@maastrichtuniversity.nl",
+      "vhp-partner": ""
     },
     "url": "https://www.maastrichtuniversity.nl/research/translational-genomics",
     "name": "Department of Translational Genomics, Maastricht University"

--- a/docs/service/aopwiki.json
+++ b/docs/service/aopwiki.json
@@ -27,7 +27,7 @@
     "contact": {
       "name": "Marvin Martens",
       "email": "marvin.martens@maastrichtuniversity.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Maastricht University"
     },
     "url": "https://www.maastrichtuniversity.nl/research/translational-genomics",
     "name": "Department of Translational Genomics, Maastricht University"

--- a/docs/service/aopwikiapi.json
+++ b/docs/service/aopwikiapi.json
@@ -16,7 +16,7 @@
     "contact": {
       "name": "Marvin Martens",
       "email": "marvin.martens@maastrichtuniversity.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Maastricht University"
     },
     "url": "https://www.maastrichtuniversity.nl/research/translational-genomics",
     "name": "Department of Translational Genomics, Maastricht University"

--- a/docs/service/aopwikiapi.json
+++ b/docs/service/aopwikiapi.json
@@ -6,6 +6,7 @@
   "substage":"https://vhp4safety.github.io/glossary#VHP0000023",
   "screenshot": "aopwikiapi.png",
   "url": "https://aopwiki-api.cloud.vhp4safety.nl/api/marvinm2/AOPWikiQueries",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -14,7 +15,8 @@
   "provider": {
     "contact": {
       "name": "Marvin Martens",
-      "email": "marvin.martens@maastrichtuniversity.nl"
+      "email": "marvin.martens@maastrichtuniversity.nl",
+      "vhp-partner": ""
     },
     "url": "https://www.maastrichtuniversity.nl/research/translational-genomics",
     "name": "Department of Translational Genomics, Maastricht University"

--- a/docs/service/arrayanalysis.json
+++ b/docs/service/arrayanalysis.json
@@ -7,6 +7,7 @@
   "url": "https://arrayanalysis.org/",
   "screenshot": "arrayanalysis.png",
   "doi": "10.1093/nar/gkt293",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -19,7 +20,8 @@
   "provider": {
     "contact": {
       "name": "Jarno Koetsier",
-      "email": "jarno.koetsier@maastrichtuniversity.nl"
+      "email": "jarno.koetsier@maastrichtuniversity.nl",
+      "vhp-partner": "Maastricht University"
     },
     "url": "https://www.maastrichtuniversity.nl/research/translational-genomics",
     "name": "Department of Translational Genomics, Maastricht University"

--- a/docs/service/asreview.json
+++ b/docs/service/asreview.json
@@ -8,6 +8,7 @@
   "doi": "10.1038/s42256-020-00287-7",
   "source": "https://github.com/asreview/asreview",
   "license": "Apache-2.0",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external"
   },

--- a/docs/service/biomodels.json
+++ b/docs/service/biomodels.json
@@ -7,6 +7,7 @@
   "screenshot": "biomodels.png",
   "url": "https://www.ebi.ac.uk/biomodels/",
   "doi": "10.1093/nar/gkz1055",
+  "developed-by-VHP": "false",
   "provider": {
     "contact": {
       "email": "biomodels-net-support@lists.sf.net"

--- a/docs/service/bmdexpress_3.json
+++ b/docs/service/bmdexpress_3.json
@@ -9,6 +9,7 @@
   "url": "https://github.com/auerbachs/BMDExpress-3",
   "doi": "10.1186/1471-2164-8-387",
   "release_notes": "https://github.com/auerbachs/BMDExpress-3?tab=readme-ov-file#updates-in-bmdexpress-3",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external",
     "license": "",

--- a/docs/service/bridgedb.json
+++ b/docs/service/bridgedb.json
@@ -7,6 +7,7 @@
   "screenshot": "bridgedb.png",
   "url": "https://www.bridgedb.org/",
   "doi": "10.1186/1471-2105-11-5",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -26,7 +27,8 @@
   },
   "provider": {
     "contact": {
-      "name": "Egon Willighagen"
+      "name": "Egon Willighagen",
+      "vhp-partner": "Maastricht University"
     },
     "name": "Department of Translational Genomics, Maastricht University"
   },

--- a/docs/service/cdkdepict.json
+++ b/docs/service/cdkdepict.json
@@ -7,7 +7,7 @@
   "screenshot": "cdkdepict.png",
   "url": "https://www.simolecule.com/cdkdepict/depict.html",
   "doi": "10.1186/s13321-017-0220-4",
-  "developed-by-VHP": "true",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",

--- a/docs/service/cdkdepict.json
+++ b/docs/service/cdkdepict.json
@@ -7,6 +7,7 @@
   "screenshot": "cdkdepict.png",
   "url": "https://www.simolecule.com/cdkdepict/depict.html",
   "doi": "10.1186/s13321-017-0220-4",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -20,7 +21,8 @@
   "provider": {
     "contact": {
       "name": "Egon Willighagen",
-      "email": "egon.willighagen@maastrichtuniversity.nl"
+      "email": "egon.willighagen@maastrichtuniversity.nl",
+      "vhp-partner": ""
     },
     "name": "simolecule"
   },

--- a/docs/service/celldesigner.json
+++ b/docs/service/celldesigner.json
@@ -7,6 +7,7 @@
   "screenshot": "celldesigner.png",
   "url": "https://www.celldesigner.org/",
   "doi": "10.1016/S1478-5382(03)02370-9",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external",
     "license": "[See licence agreement](https://www.celldesigner.org/license.txt)",

--- a/docs/service/comptox.json
+++ b/docs/service/comptox.json
@@ -6,6 +6,7 @@
   "screenshot": "comptox.png",
   "url": "https://comptox.epa.gov/dashboard/",
   "doi": "10.1186/s13321-017-0247-6",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external",
     "license": "Public Domain",

--- a/docs/service/copasi.json
+++ b/docs/service/copasi.json
@@ -5,6 +5,7 @@
   "stage": "https://vhp4safety.github.io/glossary#VHP0000156",
   "screenshot": "copasi.png",
   "url": "http://copasi.org/",
+  "developed-by-VHP": "false",
   "provider": {
     "contact": {
       "name": "The COPASI Project",

--- a/docs/service/danish_qsar_database.json
+++ b/docs/service/danish_qsar_database.json
@@ -9,6 +9,7 @@
   "url": "https://qsar.food.dtu.dk/",
   "doi": "10.1016/j.toxlet.2016.06.1479",
   "release_notes": "",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external",
     "vhp-platform": "",

--- a/docs/service/ema_documents.json
+++ b/docs/service/ema_documents.json
@@ -8,6 +8,9 @@
   "url": "https://www.ema.europa.eu/en/search",
 
 
+  "developed-by-VHP": "false",
+
+
   "provider": {
     "url": "https://www.ema.europa.eu/",
     "name": "European Medicines Agency"

--- a/docs/service/fairdomhub.json
+++ b/docs/service/fairdomhub.json
@@ -7,6 +7,7 @@
   "screenshot": "fairdomhub.png",
   "url": "https://fairdomhub.org/",
   "doi": "10.1093/nar/gkw1032",
+  "developed-by-VHP": "false",
   "provider": {
     "contact": {
       "name": "FAIRDOM",

--- a/docs/service/fairspace.json
+++ b/docs/service/fairspace.json
@@ -6,6 +6,7 @@
   "substage": "https://vhp4safety.github.io/glossary#VHP0000049",
   "screenshot": "fairspace.png",
   "url": "https://www.thehyve.nl/services/fairspace",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external",
     "license": "[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.txt)",

--- a/docs/service/farmacokompas.json
+++ b/docs/service/farmacokompas.json
@@ -11,6 +11,8 @@
 
   "url": "https://www.farmacotherapeutischkompas.nl/",
 
+  "developed-by-VHP": "false",
+
   "provider": {
     "name": "Zorginstituut Nederland",
     "url": "https://www.farmacotherapeutischkompas.nl/algemeen/contact"

--- a/docs/service/google.json
+++ b/docs/service/google.json
@@ -12,6 +12,8 @@
 
   "url": "https://google.com/",
 
+  "developed-by-VHP": "false",
+
   "instance": {
     "type": "external"
   },

--- a/docs/service/gscholar.json
+++ b/docs/service/gscholar.json
@@ -13,6 +13,8 @@
 
   "url": "https://scholar.google.com/",
 
+  "developed-by-VHP": "false",
+
   "instance": {
     "type": "external"
   },

--- a/docs/service/jrc_data_catalogue.json
+++ b/docs/service/jrc_data_catalogue.json
@@ -7,6 +7,7 @@
   "screenshot": "jrc_data_catalogue.png", 
   "url": "https://data.jrc.ec.europa.eu/",
   "doi": "10.3030/681002",
+  "developed-by-VHP": "false",
   "provider": {
     "contact": {
       "email": "jrc-data-support@ec.europa.eu"

--- a/docs/service/llemy.json
+++ b/docs/service/llemy.json
@@ -6,6 +6,7 @@
   "stage": "https://vhp4safety.github.io/glossary#VHP0000156",
   "substage": "prototype",
   "release_notes": "2025-09-02: Pilot instance; added disclaimer & license surfacing; streamlined login/API-key flow.",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "pilot",
     "deployment_docs": "https://github.com/ontox-project/Llemy",
@@ -19,7 +20,8 @@
   "provider": {
     "contact": {
       "name": "Marc Teunis",
-      "email": "marc.teunis@hu.nl"
+      "email": "marc.teunis@hu.nl",
+      "vhp-partner": "Hogeschool Utrecht"
     },
     "name": "Hogeschool Utrecht",
     "url": "https://www.hu.nl/"

--- a/docs/service/mct8-dock.json
+++ b/docs/service/mct8-dock.json
@@ -6,6 +6,7 @@
   "substage": "", 
   "url": "https://colab.research.google.com/drive/1vhy61p0z_AGnSEidwD83RwBzsW2AxAAT?usp=sharing",
   "doi": "",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "External",
     "vhp-platform": "Development",
@@ -20,7 +21,8 @@
     "name": "David Poole",
     "contact": {
       "name": "David Poole",
-      "email": "d.a.poole@vu.nl"
+      "email": "d.a.poole@vu.nl",
+      "vhp-partner": ""
     }
   },
   "access": {

--- a/docs/service/mct8-dock.json
+++ b/docs/service/mct8-dock.json
@@ -22,7 +22,7 @@
     "contact": {
       "name": "David Poole",
       "email": "d.a.poole@vu.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Vrije Universiteit;Maastricht University"
     }
   },
   "access": {

--- a/docs/service/molaopanalyser.json
+++ b/docs/service/molaopanalyser.json
@@ -8,6 +8,7 @@
     "url": "https://molaop-analyser.vhp4safety.nl/",
     "doi": "",
     "release_notes": "",
+    "developed-by-VHP": "true",
     "instance": {
         "type": "internal",
         "vhp-platform": "development",
@@ -21,7 +22,8 @@
     "provider": {
         "contact": {
             "name": "Marvin Martens",
-            "email": "marvin.martens@maastrichtuniversity.nl"
+            "email": "marvin.martens@maastrichtuniversity.nl",
+            "vhp-partner": "Maastricht University"
         },
         "name": "Maastricht University",
         "url": "maastrichtuniversity.nl"

--- a/docs/service/molaopbuilder.json
+++ b/docs/service/molaopbuilder.json
@@ -32,6 +32,7 @@
   "_ins_release_notes": "A url where there are release notes regarding the service.",
   "release_notes": "https://github.com/marvinm2/KE-WP-mapping/releases",
 
+  "developed-by-VHP": "true",
   "instance": {
 
     "_ins_type": "Whether the instance 'internal' or 'external'",
@@ -61,7 +62,8 @@
       "_ins_name": "The name of a person from the organization that provide the service.",
       "name": "Marvin Martens",
       "_ins_email": "The email of the person whose name given above.",
-      "email": "marvin.martens@maastrichtuniversity.nl"
+      "email": "marvin.martens@maastrichtuniversity.nl",
+      "vhp-partner": "Maastricht University"
     },
 
     "_ins_name": "The name of the organization that provide the service.",

--- a/docs/service/oecd_qsar_toolbox.json
+++ b/docs/service/oecd_qsar_toolbox.json
@@ -6,6 +6,7 @@
   "substage":"",
   "screenshot": "oecd_qsar_toolbox.png",
   "url": "https://qsartoolbox.org/",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external",
     "vhp-platform": "",

--- a/docs/service/ontox_physiological_maps.json
+++ b/docs/service/ontox_physiological_maps.json
@@ -5,6 +5,7 @@
   "stage": "https://vhp4safety.github.io/glossary#VHP0000156",
   "url": "https://sites.google.com/view/ontox-maps/home",
   "doi": "10.14573/altex.2412241",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external",
     "source": "https://github.com/ontox-maps/map_releases"

--- a/docs/service/oppbk_model.json
+++ b/docs/service/oppbk_model.json
@@ -8,6 +8,7 @@
   "url": "http://oppbk.cloud.vhp4safety.nl/",
   "doi": "10.1021/acs.est.4c06534",
   
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -17,7 +18,8 @@
   "provider": {
     "contact": {
       "name": "Thijs Moerenhout",
-      "email": "thijs.moerenhout@wur.nl"
+      "email": "thijs.moerenhout@wur.nl",
+      "vhp-partner": ""
     }
   },
   "regulatory-question": {

--- a/docs/service/oppbk_model.json
+++ b/docs/service/oppbk_model.json
@@ -19,7 +19,7 @@
     "contact": {
       "name": "Thijs Moerenhout",
       "email": "thijs.moerenhout@wur.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Wageningen University"
     }
   },
   "regulatory-question": {

--- a/docs/service/oqt_assistant.json
+++ b/docs/service/oqt_assistant.json
@@ -9,6 +9,7 @@
   "url": "https://github.com/VHP4Safety/O-QT-OECD-QSAR-Toolbox-AI-assistant",
   "doi": "10.1016/j.comtox.2025.100395",
   "release_notes": "2025-09-05: Initial registry entry. Clarified EULA constraints; added Docker usage note (assistant only).",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "development",
@@ -22,7 +23,8 @@
   "provider": {
     "contact": {
       "name": "Ivo Djidrovski",
-      "email": "i.djidrovski@uu.nl"
+      "email": "i.djidrovski@uu.nl",
+      "vhp-partner": ""
     },
     "name": "Utrecht University / VHP4Safety",
     "url": "https://www.uu.nl/"

--- a/docs/service/oqt_assistant.json
+++ b/docs/service/oqt_assistant.json
@@ -24,7 +24,7 @@
     "contact": {
       "name": "Ivo Djidrovski",
       "email": "i.djidrovski@uu.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Utrecht University"
     },
     "name": "Utrecht University / VHP4Safety",
     "url": "https://www.uu.nl/"

--- a/docs/service/pathvisio.json
+++ b/docs/service/pathvisio.json
@@ -7,6 +7,7 @@
   "screenshot": "pcbi.1004085.g004.png",
   "url": "https://pathvisio.org/",
   "doi": "10.1371/journal.pcbi.1004085",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "external",
     "license": "Apache-2.0 license",
@@ -16,7 +17,8 @@
 
   "provider": {
     "contact": {
-      "name": "Martina Kutmon"
+      "name": "Martina Kutmon",
+      "vhp-partner": ""
     },
     "name": "Maastricht Centre for Systems Biology and Bioinformatics",
     "url": "https://www.maastrichtuniversity.nl/research/maastricht-centre-systems-biology-and-bioinformatics"

--- a/docs/service/pathvisio.json
+++ b/docs/service/pathvisio.json
@@ -18,7 +18,7 @@
   "provider": {
     "contact": {
       "name": "Martina Kutmon",
-      "vhp-partner": ""
+      "vhp-partner": "Maastricht University"
     },
     "name": "Maastricht Centre for Systems Biology and Bioinformatics",
     "url": "https://www.maastrichtuniversity.nl/research/maastricht-centre-systems-biology-and-bioinformatics"

--- a/docs/service/qaop_app.json
+++ b/docs/service/qaop_app.json
@@ -20,7 +20,7 @@
     "contact": {
       "name": "Filippo Di Tillio",
       "email": "f.di.tillio@lacdr.leidenuniv.nl",
-      "vhp-partner": "Leiden University"
+      "vhp-partner": "Leiden University;Maastricht University"
     },
     "name": "Leiden University",
     "url": "https://www.universiteitleiden.nl/en"

--- a/docs/service/qaop_app.json
+++ b/docs/service/qaop_app.json
@@ -5,6 +5,7 @@
   "stage":"https://vhp4safety.github.io/glossary#VHP0000156",
   "substage":"https://vhp4safety.github.io/glossary#VHP0000023",
   "url": "https://qaop.vhp4safety.nl/",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "development",
@@ -18,7 +19,8 @@
   "provider": {
     "contact": {
       "name": "Filippo Di Tillio",
-      "email": "f.di.tillio@lacdr.leidenuniv.nl"
+      "email": "f.di.tillio@lacdr.leidenuniv.nl",
+      "vhp-partner": "Leiden University"
     },
     "name": "Leiden University",
     "url": "https://www.universiteitleiden.nl/en"

--- a/docs/service/qsprpred.json
+++ b/docs/service/qsprpred.json
@@ -20,7 +20,7 @@
     "contact": {
       "name": "Gerard van Westen;Linde Schoenmaker",
       "email": "gerard@gjpvanwesten.nl;l.schoenmaker@lacdr.leidenuniv.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Leiden University;Maastricht University"
     },
     "name": "Department of Medicinal Chemistry, Leiden University",
     "url": "https://www.universiteitleiden.nl/en/science/drug-research/medicinal-chemistry"

--- a/docs/service/qsprpred.json
+++ b/docs/service/qsprpred.json
@@ -6,6 +6,7 @@
   "substage":"",
   "screenshot": "qsprpred.png",
   "url": "https://qsprpred.cloud.vhp4safety.nl/",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -18,7 +19,8 @@
   "provider": {
     "contact": {
       "name": "Gerard van Westen;Linde Schoenmaker",
-      "email": "gerard@gjpvanwesten.nl;l.schoenmaker@lacdr.leidenuniv.nl"
+      "email": "gerard@gjpvanwesten.nl;l.schoenmaker@lacdr.leidenuniv.nl",
+      "vhp-partner": ""
     },
     "name": "Department of Medicinal Chemistry, Leiden University",
     "url": "https://www.universiteitleiden.nl/en/science/drug-research/medicinal-chemistry"

--- a/docs/service/r_odaf.json
+++ b/docs/service/r_odaf.json
@@ -22,7 +22,7 @@
   "contact": {
     "name": "VHP4Safety Support;Saad Lodhi;Danyel Jennen",
     "email": "vhp4safety@uu.nl;saad.lodhi@maastrichtuniversity.nl;danyel.jennen@maastrichtuniversity.nl",
-    "vhp-partner": ""
+    "vhp-partner": "Maastricht University"
   },
   "additional_contacts": [
     {

--- a/docs/service/r_odaf.json
+++ b/docs/service/r_odaf.json
@@ -6,6 +6,7 @@
   "stage": "Other",
   "substage": "Transcriptomics / Differential Expression",
   "screenshot": "r_odaf.png",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "development",
@@ -20,7 +21,8 @@
   "provider": {
   "contact": {
     "name": "VHP4Safety Support;Saad Lodhi;Danyel Jennen",
-    "email": "vhp4safety@uu.nl;saad.lodhi@maastrichtuniversity.nl;danyel.jennen@maastrichtuniversity.nl"
+    "email": "vhp4safety@uu.nl;saad.lodhi@maastrichtuniversity.nl;danyel.jennen@maastrichtuniversity.nl",
+    "vhp-partner": ""
   },
   "additional_contacts": [
     {

--- a/docs/service/robot.json
+++ b/docs/service/robot.json
@@ -25,7 +25,7 @@
     "contact": {
       "name": "Abhishek Chattopadhyay ",
       "email": "a.chattopadhyay@maastrichtuniversity.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Maastricht University"
     },
 
     "name": "Maastricht University",

--- a/docs/service/robot.json
+++ b/docs/service/robot.json
@@ -9,6 +9,7 @@
   "url": "",
   "doi": "",
   "release_notes": "",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "development",
@@ -23,7 +24,8 @@
   "provider": {
     "contact": {
       "name": "Abhishek Chattopadhyay ",
-      "email": "a.chattopadhyay@maastrichtuniversity.nl"
+      "email": "a.chattopadhyay@maastrichtuniversity.nl",
+      "vhp-partner": ""
     },
 
     "name": "Maastricht University",

--- a/docs/service/sombie.json
+++ b/docs/service/sombie.json
@@ -4,6 +4,7 @@
   "description": "A webservice for prediction of protein-structure and reactivity based (P450) site-of-metabolism.",
   "stage": "https://vhp4safety.github.io/glossary#VHP0000155",
   "url": "https://sombie.cloud.vhp4safety.nl/",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -17,7 +18,8 @@
   "provider": {
     "contact": {
       "name": "David Poole",
-      "email": "d.a.poole@vu.nl"
+      "email": "d.a.poole@vu.nl",
+      "vhp-partner": ""
     }
   },
   "access": {

--- a/docs/service/sombie.json
+++ b/docs/service/sombie.json
@@ -19,7 +19,7 @@
     "contact": {
       "name": "David Poole",
       "email": "d.a.poole@vu.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Vrije Universiteit"
     }
   },
   "access": {

--- a/docs/service/sysrev.json
+++ b/docs/service/sysrev.json
@@ -6,6 +6,7 @@
   "substage": "https://vhp4safety.github.io/glossary#VHP0000053",
   "url": "https://sysrev.com/",
   "doi": "10.3389/frai.2021.685298",
+  "developed-by-VHP": "false",
   "instance": {
     "type": "external"
   },

--- a/docs/service/template.json
+++ b/docs/service/template.json
@@ -32,6 +32,9 @@
   "_ins_release_notes": "A url where there are release notes regarding the service.",
   "release_notes": "",
 
+  "_ins_developed-by-VHP": "Whether the service was developed by a VHP4Safety partner. Answer 'true' or 'false'.",
+  "developed-by-VHP": "",
+
   "instance": {
 
     "_ins_deployment_docs": "Where are the deployment instructions located?",
@@ -64,7 +67,10 @@
       "_ins_name": "The name of a person from the organization that provide the service. More than one contact information can be provided by putting a ';' between their names (e.g. author1;author2). Please be careful to give an email address for each contact person in the next field, otherwise the contact information may not be displayed correctly.",
       "name": "",
       "_ins_email": "The email(s) of the person(s) whose name(s) given above. More than one contact information can be provided by putting a ';' between their email addresses (e.g. author1@mail.com;author2@mail.com). Please be careful to give an email address for each contact person in the previous field, otherwise the contact information may not be displayed correctly.",
-      "email": ""
+      "email": "",
+
+      "_ins_vhp-partner": "The VHP4Safety partner organisation(s) that developed the service. Multiple partners separated by ';' without spaces (e.g., partner1;partner2). Leave empty for services not developed by a VHP partner.",
+      "vhp-partner": ""
     },
 
     "_ins_name": "The name of the organization that provide the service.",

--- a/docs/service/toxtemp_assistant.json
+++ b/docs/service/toxtemp_assistant.json
@@ -9,6 +9,7 @@
   "url": "https://toxtempassistant.vhp4safety.nl/",
   "doi": "10.1080/2833373X.2026.2638036",
   "release_notes": "",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "development",
@@ -22,7 +23,8 @@
   "provider": {
     "contact": {
       "name": "Jente Houweling",
-      "email": "jente.houweling@rivm.nl"
+      "email": "jente.houweling@rivm.nl",
+      "vhp-partner": ""
     },
     "name": "Maastricht University",
     "url": "https://www.maastrichtuniversity.nl/"

--- a/docs/service/toxtemp_assistant.json
+++ b/docs/service/toxtemp_assistant.json
@@ -24,7 +24,7 @@
     "contact": {
       "name": "Jente Houweling",
       "email": "jente.houweling@rivm.nl",
-      "vhp-partner": ""
+      "vhp-partner": "RIVM;Maastricht University"
     },
     "name": "Maastricht University",
     "url": "https://www.maastrichtuniversity.nl/"

--- a/docs/service/txg_mapr.json
+++ b/docs/service/txg_mapr.json
@@ -7,6 +7,7 @@
   "screenshot": "txg_mapr.png",
   "url": "https://txg-mapr.eu/",
   "doi": "10.1007/s00204-021-03141-w",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "External",
@@ -15,7 +16,8 @@
   "provider": {
     "contact": {
       "name": "Steven J. Kunnen",
-      "email": "s.j.kunnen@lacdr.leidenuniv.nl"
+      "email": "s.j.kunnen@lacdr.leidenuniv.nl",
+      "vhp-partner": ""
     },
     "name": "Leiden University"
   },

--- a/docs/service/txg_mapr.json
+++ b/docs/service/txg_mapr.json
@@ -17,7 +17,7 @@
     "contact": {
       "name": "Steven J. Kunnen",
       "email": "s.j.kunnen@lacdr.leidenuniv.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Leiden University"
     },
     "name": "Leiden University"
   },

--- a/docs/service/vhp_glossary.json
+++ b/docs/service/vhp_glossary.json
@@ -10,6 +10,7 @@
   "doi": "10.14573/altex.2407211",
   "release_notes": "https://github.com/VHP4Safety/glossary/commits/main/",
 
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "development",
@@ -19,7 +20,8 @@
   "provider": {
     "contact": {
       "name": "VHP4Safety",
-      "email": "vhp4safety@uu.nl"
+      "email": "vhp4safety@uu.nl",
+      "vhp-partner": ""
     },
     "name": "VHP4Safety Project",
     "url": "https://vhp4safety.nl/"

--- a/docs/service/vhp_glossary.json
+++ b/docs/service/vhp_glossary.json
@@ -21,7 +21,7 @@
     "contact": {
       "name": "VHP4Safety",
       "email": "vhp4safety@uu.nl",
-      "vhp-partner": ""
+      "vhp-partner": "Maastricht University"
     },
     "name": "VHP4Safety Project",
     "url": "https://vhp4safety.nl/"

--- a/docs/service/wikipathways_aop.json
+++ b/docs/service/wikipathways_aop.json
@@ -7,6 +7,7 @@
   "screenshot": "wikipathways_aop.png",
   "url": "https://aop.wikipathways.org/",
   "doi": "10.3389/fgene.2018.00661",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "External",
@@ -20,7 +21,8 @@
   "provider": {
     "contact": {
       "name": "Marvin Martens",
-      "email": "marvin.martens@maastrichtuniversity.nl"
+      "email": "marvin.martens@maastrichtuniversity.nl",
+      "vhp-partner": "Maastricht University"
     },
     "url": "",
     "name": "Maastricht University"

--- a/docs/service/xploreaop.json
+++ b/docs/service/xploreaop.json
@@ -5,6 +5,7 @@
   "stage": "https://vhp4safety.github.io/glossary#VHP0000156",
   "substage": "https://vhp4safety.github.io/glossary#VHP0000023",
   "url": "https://xploreaop.cloud.vhp4safety.nl/",
+  "developed-by-VHP": "true",
   "instance": {
     "type": "internal",
     "vhp-platform": "Development",
@@ -14,7 +15,8 @@
   },
   "provider": {
     "contact": {
-      "name": "Marc Teunis"
+      "name": "Marc Teunis",
+      "vhp-partner": "Hogeschool Utrecht"
     },
     "name": "Hogeschool Utrecht"
   },

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,7 +4,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
       http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!-- Sitemap created on 2026-04-17 13:15:33.501041. -->
+<!-- Sitemap created on 2026-05-20 11:16:26.890564. -->
 
 <!-- parsing file: docs/service/aop-builder.json -->
 <url>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,7 +4,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
       http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!-- Sitemap created on 2026-05-20 11:22:38.474366. -->
+<!-- Sitemap created on 2026-05-20 11:27:16.804577. -->
 
 <!-- parsing file: docs/service/aop-builder.json -->
 <url>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,7 +4,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
       http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!-- Sitemap created on 2026-05-20 11:16:26.890564. -->
+<!-- Sitemap created on 2026-05-20 11:22:38.474366. -->
 
 <!-- parsing file: docs/service/aop-builder.json -->
 <url>


### PR DESCRIPTION
Adds a top-level `developed-by-VHP` flag and a `vhp-partner` field under `provider.contact` to the service JSON schema, plus backfilled values across the catalog. Additive only — no generator or template changes; rendering can be wired up in a follow-up if/when wanted.

Implements Egon's Slack request to capture VHP-developer provenance as a real schema field.

## Test plan
- [ ] CI: `Generate material (R version)` passes
- [ ] CI: `Collect Service Meta-Data for CAP` passes
- [ ] No unexpected diff in `docs/service/*.md` or `docs/index.md`
- [ ] @egonw confirms field naming / placement