### PR TITLE
Update molAOP Builder entry: repository renamed, version bump, API auth flag

### DIFF
--- a/cap/service_index.json
+++ b/cap/service_index.json
@@ -517,7 +517,7 @@
     "md_file_name": "molaopbuilder.md",
     "png_file_name": "molaopbuilder.png",
     "stage": "https://vhp4safety.github.io/glossary#VHP0000156",
-    "main_url": "https://github.com/marvinm2/KE-WP-mapping",
+    "main_url": "https://github.com/marvinm2/molAOP-builder",
     "inst_url": "https://molaop-builder.vhp4safety.nl/",
     "reg_q_1a": "",
     "reg_q_1b": "",

--- a/docs/service/molaopbuilder.json
+++ b/docs/service/molaopbuilder.json
@@ -24,16 +24,16 @@
   "screenshot": "molaopbuilder.png",
 
   "_ins_url": "The original URL to the service.",
-  "url": "https://github.com/marvinm2/KE-WP-mapping",
+  "url": "https://github.com/marvinm2/molAOP-builder",
 
   "_ins_deployment_docs": "URL with deployment / install documentation.",
-  "deployment_docs": "https://github.com/marvinm2/KE-WP-mapping#quick-start",
+  "deployment_docs": "https://github.com/marvinm2/molAOP-builder#quick-start",
 
   "_ins_doi": "The DOI of the document (article, preprint, etc.) related to the service.",
   "doi": "",
 
   "_ins_release_notes": "A url where there are release notes regarding the service.",
-  "release_notes": "https://github.com/marvinm2/KE-WP-mapping/releases",
+  "release_notes": "https://github.com/marvinm2/molAOP-builder/releases",
 
   "developed-by-VHP": "true",
   "instance": {
@@ -48,13 +48,13 @@
     "url": "https://molaop-builder.vhp4safety.nl/",
 
     "license": "GPL-2.0",
-    "version": "2.3.0",
+    "version": "2.8.0",
 
     "ins_source": "Link to the source material of the service.",
-    "source": "https://github.com/marvinm2/KE-WP-mapping",
+    "source": "https://github.com/marvinm2/molAOP-builder",
 
     "_ins_docker": "Link to the repository with service's Docker container.",
-    "docker": "https://github.com/marvinm2/KE-WP-mapping/pkgs/container/ke-wp-mapping",
+    "docker": "https://github.com/marvinm2/molAOP-builder/pkgs/container/molaop-builder",
 
     "_ins_TRL": "Technology Readiness Level. For details, please see: https://en.wikipedia.org/wiki/Technology_readiness_level",
     "TRL": ""
@@ -81,7 +81,7 @@
     "API": "REST",
 
     "_ins_login": "Whether the API requires authenication.",
-    "login": "true",
+    "login": "false",
 
     "packages": {
       "R": "",

--- a/docs/service/molaopbuilder.md
+++ b/docs/service/molaopbuilder.md
@@ -7,7 +7,7 @@ A curator-in-the-loop web application that maps AOP Key Events to WikiPathways p
 
 ![Molecular AOP Builder logo](https://raw.githubusercontent.com/VHP4Safety/cloud/main/docs/service/molaopbuilder.png)
 
-**Main Webpage:** [https://github.com/marvinm2/KE-WP-mapping](https://github.com/marvinm2/KE-WP-mapping)
+**Main Webpage:** [https://github.com/marvinm2/molAOP-builder](https://github.com/marvinm2/molAOP-builder)
 
 **Tool Webpage:** [https://molaop-builder.vhp4safety.nl/](https://molaop-builder.vhp4safety.nl/)
 
@@ -59,7 +59,7 @@ A curator-in-the-loop web application that maps AOP Key Events to WikiPathways p
 
 * Development Cloud: [https://molaop-builder.vhp4safety.nl/](https://molaop-builder.vhp4safety.nl/) 
 
-* Login Required: true
+* Login Required: false
 
 * TRL: 
 
@@ -77,13 +77,13 @@ A curator-in-the-loop web application that maps AOP Key Events to WikiPathways p
 
 * Citation: [](https://doi.org/)
 
-* Version: 2.3.0
+* Version: 2.8.0
 
 * License: GPL-2.0
 
-* Source Code: [https://github.com/marvinm2/KE-WP-mapping](https://github.com/marvinm2/KE-WP-mapping)
+* Source Code: [https://github.com/marvinm2/molAOP-builder](https://github.com/marvinm2/molAOP-builder)
 
-* Docker: [https://github.com/marvinm2/KE-WP-mapping/pkgs/container/ke-wp-mapping](https://github.com/marvinm2/KE-WP-mapping/pkgs/container/ke-wp-mapping)
+* Docker: [https://github.com/marvinm2/molAOP-builder/pkgs/container/molaop-builder](https://github.com/marvinm2/molAOP-builder/pkgs/container/molaop-builder)
 
 * Bio.tools: [](https://bio.tools/)
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,7 +4,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
       http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!-- Sitemap created on 2026-07-21 15:47:52.190791. -->
+<!-- Sitemap created on 2026-07-21 16:27:14.190784. -->
 
 <!-- parsing file: docs/service/aop-builder.json -->
 <url>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,7 +4,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
       http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!-- Sitemap created on 2026-05-27 04:36:47.891247. -->
+<!-- Sitemap created on 2026-07-21 12:47:04.76869. -->
 
 <!-- parsing file: docs/service/aop-builder.json -->
 <url>

--- a/docs/tools.tsv
+++ b/docs/tools.tsv
@@ -31,7 +31,7 @@ jrc_data_catalogue	Joint Research Centre Data Catalogue	https://data.jrc.ec.euro
 llemy	Llemy	NA	https://llemy.vhp4safety.nl/
 mct8-dock	MCT8 Docking for MIE Discovery	https://mct8-docking.vhp4safety.nl/	https://mct8-docking.vhp4safety.nl/#docking
 molaopanalyser	MolAOP analyser	https://molaop-analyser.vhp4safety.nl/	https://molaop-analyser.vhp4safety.nl/
-molaopbuilder	Molecular AOP Builder	https://github.com/marvinm2/KE-WP-mapping	https://molaop-builder.vhp4safety.nl/
+molaopbuilder	Molecular AOP Builder	https://github.com/marvinm2/molAOP-builder	https://molaop-builder.vhp4safety.nl/
 oecd_qsar_toolbox	The OECD QSAR Toolbox	https://qsartoolbox.org/	
 ontox_physiological_maps	ONTOX Physiological Maps	https://sites.google.com/view/ontox-maps/home	NA
 oppbk_model	OP PBK Model	http://oppbk.cloud.vhp4safety.nl/	http://oppbk.cloud.vhp4safety.nl/


### PR DESCRIPTION
Housekeeping on `docs/service/molaopbuilder.json` after renaming the upstream repository. JSON only — the generator workflow regenerates `molaopbuilder.md` from it.

## Changes

| field | from | to |
|---|---|---|
| `url` | `marvinm2/KE-WP-mapping` | `marvinm2/molAOP-builder` |
| `deployment_docs` | `.../KE-WP-mapping#quick-start` | `.../molAOP-builder#quick-start` |
| `release_notes` | `.../KE-WP-mapping/releases` | `.../molAOP-builder/releases` |
| `instance.source` | `marvinm2/KE-WP-mapping` | `marvinm2/molAOP-builder` |
| `instance.docker` | `.../KE-WP-mapping/pkgs/container/ke-wp-mapping` | `.../molAOP-builder/pkgs/container/molaop-builder` |
| `instance.version` | `2.3.0` | `2.8.0` |
| `access.login` | `true` | `false` |

**Repository rename.** `marvinm2/KE-WP-mapping` is now `marvinm2/molAOP-builder`. The old name dated from when the tool only mapped Key Events to WikiPathways; it now covers WikiPathways, GO and Reactome. GitHub redirects the old URLs, so nothing was broken — but the catalog should name the real repository.

**Container link was wrong in two ways.** Both the repository *and* the package name were stale: the published package is `molaop-builder`, not `ke-wp-mapping`. Verified the corrected target is real and public via an anonymous registry pull:

```
GET https://ghcr.io/v2/marvinm2/molaop-builder/manifests/latest -> 200
```

**`access.login`.** The service's public REST API (`/api/v1`) requires no authentication — it is open, rate-limited to 100 req/h/IP. Only the mutation endpoints (submitting mappings and proposals) need a login, so `true` overstated the barrier for anyone browsing the catalog for reusable APIs.

**Version.** The deployed release is 2.8.0 per the repository CHANGELOG.

## Notes for maintainers

- `docs/service/ke-wp-mapping.md` looks like an **orphan**: it is an autogenerated page with no corresponding `ke-wp-mapping.json`, left over from before this service was renamed to `molaopbuilder`. It duplicates `molaopbuilder.md` and still carries the pre-v1.5 description ("gene overlap, text similarity"), which no longer reflects how the tool ranks suggestions. I have not touched it, in case the path is intentionally kept for existing links — but it is stale content either way.
- I left `doi` empty. The dataset now has a Zenodo concept DOI ([10.5281/zenodo.20184643](https://doi.org/10.5281/zenodo.20184643)), but the field is documented as the DOI of a related *article/preprint*, which is not out yet. Happy to add it if the field is meant more broadly.